### PR TITLE
feat: 찜한페이지(in 마이페이지), 모든 투어아이템 컴포넌트에 찜아이콘 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/base": "^5.0.0-beta.24",
-        "@mui/icons-material": "^5.14.18",
+        "@mui/icons-material": "^5.14.19",
         "@mui/lab": "^5.0.0-alpha.153",
         "@mui/material": "^5.14.18",
         "@mui/system": "^5.14.18",
@@ -812,18 +812,18 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.14.18",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.18.tgz",
-      "integrity": "sha512-o2z49R1G4SdBaxZjbMmkn+2OdT1bKymLvAYaB6pH59obM1CYv/0vAVm6zO31IqhwtYwXv6A7sLIwCGYTaVkcdg==",
+      "version": "5.14.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
+      "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2"
+        "@babel/runtime": "^7.23.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/base": "^5.0.0-beta.24",
-    "@mui/icons-material": "^5.14.18",
+    "@mui/icons-material": "^5.14.19",
     "@mui/lab": "^5.0.0-alpha.153",
     "@mui/material": "^5.14.18",
     "@mui/system": "^5.14.18",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,7 +53,6 @@ function App() {
                   element={<DetailPage />}
                 />
                 <Route path="/tourDetail/:tourId" element={<TourDetail />} />
-                <Route path="/like" element={<LikedPlace />} />
               </Route>
             </Routes>
           </QueryClientProvider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import SearchHotelList from './pages/search/SearchHotelList'
 import SearchTourList from './pages/search/SearchTourList'
 import TourDetail from './pages/tour/tourDetail'
 import MyPage from './pages/main/Mypage/Mypage'
-import LikedPlace from './components/tempMyPage/likedPlaces'
+import LikedAttractions from './pages/main/Mypage/LikedAttractions'
 
 function App() {
   const theme = createTheme()
@@ -38,7 +38,9 @@ function App() {
                 <Route path="/hotel" element={<HotelPage />} />
                 <Route path="/hotel/search" element={<HotelSearchPage />} />
                 <Route path="/myPage" element={<MyPage />} />
-                {/* 통합검색, 호텔리스트, 여행지리스트 */}
+                {/* 마이페이지에 아울렛으로 넣어야 할것같은데 확인 위해 일단 빼 두었습니다 */}
+                <Route path="/like" element={<LikedAttractions />} />
+
                 <Route path="/searchList/:keyword" element={<SearchPage />} />
                 <Route
                   path="/searchHotelList/:keyword"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import SearchHotelList from './pages/search/SearchHotelList'
 import SearchTourList from './pages/search/SearchTourList'
 import TourDetail from './pages/tour/tourDetail'
 import MyPage from './pages/main/Mypage/Mypage'
+import LikedPlace from './components/tempMyPage/likedPlaces'
 
 function App() {
   const theme = createTheme()
@@ -52,6 +53,7 @@ function App() {
                   element={<DetailPage />}
                 />
                 <Route path="/tourDetail/:tourId" element={<TourDetail />} />
+                <Route path="/like" element={<LikedPlace />} />
               </Route>
             </Routes>
           </QueryClientProvider>

--- a/src/components/search/SearchCard.jsx
+++ b/src/components/search/SearchCard.jsx
@@ -128,16 +128,9 @@ function SearchCard({ hotels, attractions, keyword }) {
               <Box className="grid w-full max-w-6xl sm:grid-cols-1 sm:gap-x-6 md:grid-cols-2 xl:grid-cols-3">
                 {attractions.length ? (
                   attractions.map((attraction) => (
-                    // setIsAttractionLiked(attraction.attractionId)
-
                     <TourItem
                       key={attraction.attractionId}
                       attraction={attraction}
-                      addLikedAttraction={addLikedAttraction}
-                      deleteLikedAttraction={deleteLikedAttraction}
-                      likedAttractions={likedAttractions}
-                      isAttractionLiked={isAttractionLiked}
-                      setIsAttractionLiked={setIsAttractionLiked}
                     />
                   ))
                 ) : (

--- a/src/components/search/SearchCard.jsx
+++ b/src/components/search/SearchCard.jsx
@@ -4,8 +4,14 @@ import { FiChevronRight } from 'react-icons/fi'
 import SideBar from './SideBar'
 import HotelItem from './HotelItem'
 import TourItem from './TourItem'
+import { useStore } from '../store/store'
 
 function SearchCard({ hotels, attractions, keyword }) {
+  const { isAttractionLiked, setIsAttractionLiked } = useStore()
+  const addLikedAttraction = useStore((store) => store.addLikedAttraction)
+  const deleteLikedAttraction = useStore((store) => store.deleteLikedAttraction)
+  const likedAttractions = useStore((store) => store.likedAttractions)
+
   return (
     <Box className="flex flex-col items-center gap-3">
       <Typography
@@ -119,12 +125,19 @@ function SearchCard({ hotels, attractions, keyword }) {
                 여행지
               </Typography>
 
-              <Box className="grid w-full max-w-6xl  sm:grid-cols-1 sm:gap-x-6 md:grid-cols-2 xl:grid-cols-3">
+              <Box className="grid w-full max-w-6xl sm:grid-cols-1 sm:gap-x-6 md:grid-cols-2 xl:grid-cols-3">
                 {attractions.length ? (
                   attractions.map((attraction) => (
+                    // setIsAttractionLiked(attraction.attractionId)
+
                     <TourItem
                       key={attraction.attractionId}
                       attraction={attraction}
+                      addLikedAttraction={addLikedAttraction}
+                      deleteLikedAttraction={deleteLikedAttraction}
+                      likedAttractions={likedAttractions}
+                      isAttractionLiked={isAttractionLiked}
+                      setIsAttractionLiked={setIsAttractionLiked}
                     />
                   ))
                 ) : (

--- a/src/components/search/TourItem.jsx
+++ b/src/components/search/TourItem.jsx
@@ -1,76 +1,131 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Box, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
+import { CiHeart } from 'react-icons/ci'
+import { FaHeart } from 'react-icons/fa'
+import { useStore } from '../store/store'
 
-function TourItem({ attraction, smallCard }) {
+function TourItem({
+  attraction,
+  smallCard,
+  // likedAttractions,
+  // addLikedAttraction,
+  // deleteLikedAttraction,
+  // isAttractionLiked,
+  // setIsAttractionLiked,
+}) {
   const city = useMemo(
     () => (attraction?.address ? attraction.address.split(' ')[0] : ''),
     [attraction],
   )
 
+  const [isAttractionLiked, setIsAttractionLiked] = useState(false)
+  const addLikedAttraction = useStore((store) => store.addLikedAttraction)
+  const deleteLikedAttraction = useStore((store) => store.deleteLikedAttraction)
+  const likedAttractions = useStore((store) => store.likedAttractions)
+
+  const handleLikedAttraction = () => {
+    if (isAttractionLiked) {
+      console.log('딜리트실행')
+      deleteLikedAttraction(attraction.attractionId)
+    } else {
+      console.log('에드실행됨')
+      addLikedAttraction(attraction)
+    }
+  }
+
+  useEffect(() => {
+    setIsAttractionLiked(
+      likedAttractions?.some(
+        (attr) => attr.attractionId === attraction.attractionId,
+      ),
+    )
+  }, [attraction, likedAttractions, handleLikedAttraction])
+
   return (
-    <Link to={`/tourDetail/${attraction.attractionId}`}>
-      <Box
-        className={`group relative flex overflow-hidden border border-solid border-gray-200 bg-white ${
-          smallCard
-            ? 'h-23 mb-2'
-            : 'h-29 mb-6 hover:border-blue-200 hover:shadow-lg hover:shadow-blue-100'
-        }`}
-      >
+    <Box>
+      <Link to={`/tourDetail/${attraction.attractionId}`}>
         <Box
-          className={` overflow-hidden
+          className={`group relative flex overflow-hidden border border-solid border-gray-200 bg-white ${
+            smallCard
+              ? 'h-23 mb-2'
+              : 'h-29 mb-6 hover:border-blue-200 hover:shadow-lg hover:shadow-blue-100'
+          }`}
+        >
+          <Box
+            className={` overflow-hidden
             ${smallCard ? 'h-[6rem] w-[6rem]' : 'h-[8rem] w-[8rem]'}
           `}
-        >
-          <img
-            src={`/src/assets/img/attraction/${attraction.mainImage}`}
-            className={`object-cover 
+          >
+            <img
+              src={`/src/assets/img/attraction/${attraction.mainImage}`}
+              className={`object-cover 
               ${
                 smallCard
                   ? 'h-[6rem] w-[6rem]'
                   : 'h-[8rem] w-[8rem] overflow-hidden duration-1000 group-hover:scale-125'
               }`}
-            alt={`attraction ${attraction.attractionId}`}
-          />
-        </Box>
-        <Box className=" flex flex-col items-start justify-start gap-1 px-2 py-1.5 text-gray-500">
-          <Typography
-            variant="body1"
-            className=" text-gray-900"
-            style={{ fontWeight: 600 }}
-          >
-            {attraction.name}
-          </Typography>
-          <Typography variant="body1" className="-mt-1">
-            {city}
-          </Typography>
+              alt={`attraction ${attraction.attractionId}`}
+            />
+          </Box>
+          <Box className=" flex flex-col items-start justify-start gap-1 px-2 py-1.5 text-gray-500">
+            <Typography
+              variant="body1"
+              className=" text-gray-900"
+              style={{ fontWeight: 600 }}
+            >
+              {attraction.name}
+            </Typography>
+            <Typography variant="body1" className="-mt-1">
+              {city}
+            </Typography>
 
-          <Box className="-mt-1.5">
-            <Typography
-              variant="body1"
-              className=" text-blue-500"
-              style={smallCard ? { display: 'inline' } : { display: 'inline' }}
-            >
-              {attraction.avgRating}
-            </Typography>
-            <Typography
-              variant="body2"
-              className=" text-gray-500"
-              style={{ display: 'inline' }}
-            >
-              /5
-            </Typography>
-            <Typography
-              variant="body1"
-              className="ml-2"
-              style={{ marginLeft: '0.5rem', display: 'inline' }}
-            >
-              {attraction.reviewCount}건의 리뷰
-            </Typography>
+            <Box className="-mt-1.5">
+              <Typography
+                variant="body1"
+                className=" text-blue-500"
+                style={
+                  smallCard ? { display: 'inline' } : { display: 'inline' }
+                }
+              >
+                {attraction.avgRating}
+              </Typography>
+              <Typography
+                variant="body2"
+                className=" text-gray-500"
+                style={{ display: 'inline' }}
+              >
+                /5
+              </Typography>
+              <Typography
+                variant="body1"
+                className="ml-2"
+                style={{ marginLeft: '0.5rem', display: 'inline' }}
+              >
+                {attraction.reviewCount}건의 리뷰
+              </Typography>
+            </Box>
           </Box>
         </Box>
-      </Box>
-    </Link>
+      </Link>
+      <Button>
+        {isAttractionLiked ? (
+          <FaHeart
+            onClick={() => {
+              handleLikedAttraction()
+            }}
+            className="w-7 h-7 mr-1 text-blue-700"
+          />
+        ) : (
+          <CiHeart
+            onClick={() => {
+              handleLikedAttraction()
+            }}
+            className="w-9 h-9"
+          />
+        )}
+      </Button>
+    </Box>
   )
 }
 

--- a/src/components/search/TourItem.jsx
+++ b/src/components/search/TourItem.jsx
@@ -3,17 +3,10 @@ import { Link } from 'react-router-dom'
 import { Box, Button, Typography } from '@mui/material'
 import { CiHeart } from 'react-icons/ci'
 import { FaHeart } from 'react-icons/fa'
+import Checkbox from '@mui/material/Checkbox'
 import { useStore } from '../store/store'
 
-function TourItem({
-  attraction,
-  smallCard,
-  // likedAttractions,
-  // addLikedAttraction,
-  // deleteLikedAttraction,
-  // isAttractionLiked,
-  // setIsAttractionLiked,
-}) {
+function TourItem({ attraction, smallCard, likedPage }) {
   const city = useMemo(
     () => (attraction?.address ? attraction.address.split(' ')[0] : ''),
     [attraction],
@@ -26,10 +19,8 @@ function TourItem({
 
   const handleLikedAttraction = () => {
     if (isAttractionLiked) {
-      console.log('딜리트실행')
       deleteLikedAttraction(attraction.attractionId)
     } else {
-      console.log('에드실행됨')
       addLikedAttraction(attraction)
     }
   }
@@ -42,8 +33,25 @@ function TourItem({
     )
   }, [attraction, likedAttractions, handleLikedAttraction])
 
+  const [checked, setChecked] = useState(true)
+
+  const handleChange = (event) => {
+    setChecked(event.target.checked)
+  }
+  const label = {
+    inputProps: {
+      'aria-label': 'Checkbox demo',
+      style: {
+        position: 'absolute',
+        top: '4rem',
+        left: '-3rem',
+        fontSize: '28px',
+      },
+    },
+  }
+
   return (
-    <Box>
+    <Box className={`relative ${likedPage ? 'pl-20' : ''}`}>
       <Link to={`/tourDetail/${attraction.attractionId}`}>
         <Box
           className={`group relative flex overflow-hidden border border-solid border-gray-200 bg-white ${
@@ -108,13 +116,20 @@ function TourItem({
           </Box>
         </Box>
       </Link>
-      <Button>
+      <Button
+        style={{
+          position: 'absolute',
+          top: '0',
+          right: '-0.5rem',
+          borderRadius: '50%',
+        }}
+      >
         {isAttractionLiked ? (
           <FaHeart
             onClick={() => {
               handleLikedAttraction()
             }}
-            className="w-7 h-7 mr-1 text-blue-700"
+            className="w-7 h-7 mt-1 text-blue-700"
           />
         ) : (
           <CiHeart

--- a/src/components/store/store.js
+++ b/src/components/store/store.js
@@ -5,9 +5,17 @@ const store = (set) => ({
   likedAttractions: [],
   addLikedAttraction: (attraction) =>
     set(
-      (state) => ({
-        likedAttractions: [...state.likedAttractions, attraction],
-      }),
+      (state) => {
+        const attractionExists = state.likedAttractions.some(
+          (item) => item.attractionId === attraction.attractionId,
+        )
+        if (!attractionExists) {
+          return {
+            likedAttractions: [...state.likedAttractions, attraction],
+          }
+        }
+        return state
+      },
       false,
       'addLikedAttraction',
     ),
@@ -22,7 +30,7 @@ const store = (set) => ({
       'deleteLikedAttraction',
     ),
   isAttractionLiked: false,
-  setAttractionLiked: (id) =>
+  setIsAttractionLiked: (id) =>
     set(
       (state) => ({
         isAttractionLiked: state.likedAttractions.some(
@@ -34,4 +42,5 @@ const store = (set) => ({
     ),
 })
 
+// export const useStore = create(devtools(store), { name: 'store' })
 export const useStore = create(persist(devtools(store), { name: 'store' }))

--- a/src/components/store/store.js
+++ b/src/components/store/store.js
@@ -3,6 +3,15 @@ import { devtools, persist } from 'zustand/middleware'
 
 const store = (set) => ({
   likedAttractions: [],
+  // 로그인시 유저 정보 조회 후 setLikedAttraction(data.favoriteAttractions)
+  setLikedAttraction: (fetchedAttractions) =>
+    set(
+      () => ({
+        likedAttractions: [...fetchedAttractions],
+      }),
+      false,
+      'setLikedAttraction',
+    ),
   addLikedAttraction: (attraction) =>
     set(
       (state) => {
@@ -29,18 +38,6 @@ const store = (set) => ({
       false,
       'deleteLikedAttraction',
     ),
-  isAttractionLiked: false,
-  setIsAttractionLiked: (id) =>
-    set(
-      (state) => ({
-        isAttractionLiked: state.likedAttractions.some(
-          (attraction) => attraction.attractionId === id,
-        ),
-      }),
-      false,
-      'setAttractionLiked',
-    ),
 })
 
-// export const useStore = create(devtools(store), { name: 'store' })
 export const useStore = create(persist(devtools(store), { name: 'store' }))

--- a/src/components/tour/TourDetailHeader.jsx
+++ b/src/components/tour/TourDetailHeader.jsx
@@ -8,6 +8,7 @@ import { Typography } from '@mui/material'
 import { Button } from '@mui/base'
 import moment from 'moment/moment'
 import { shallow } from 'zustand/shallow'
+import { useEffect, useState } from 'react'
 import { useStore } from '../store/store'
 
 export default function TourDetailHeader({ mainAttraction, city }) {
@@ -53,23 +54,29 @@ export default function TourDetailHeader({ mainAttraction, city }) {
   }
 
   const likedAttractions = useStore((store) => store.likedAttractions)
-  const setAttractionLiked = useStore((store) => store.setAttractionLiked)
 
-  const isAttractionLiked = useStore((store) => store.isAttractionLiked)
+  const [isAttractionLiked, setIsAttractionLiked] = useState(false)
 
   const addLikedAttraction = useStore((store) => store.addLikedAttraction)
   const deleteLikedAttraction = useStore((store) => store.deleteLikedAttraction)
 
   const handleLikedAttraction = () => {
-    setAttractionLiked(mainAttraction.attractionId)
+    setIsAttractionLiked(mainAttraction.attractionId)
     if (isAttractionLiked) {
       deleteLikedAttraction(mainAttraction.attractionId)
     } else {
       // 여기서 로그인 체크 필요
       addLikedAttraction(mainAttraction)
     }
-    setAttractionLiked(mainAttraction.attractionId)
   }
+
+  useEffect(() => {
+    setIsAttractionLiked(
+      likedAttractions?.some(
+        (attr) => attr.attractionId === mainAttraction.attractionId,
+      ),
+    )
+  }, [handleLikedAttraction])
 
   return (
     <Box className="flex flex-col gap-2 p-3">

--- a/src/components/tour/TourDetailHeader.jsx
+++ b/src/components/tour/TourDetailHeader.jsx
@@ -61,11 +61,11 @@ export default function TourDetailHeader({ mainAttraction, city }) {
   const deleteLikedAttraction = useStore((store) => store.deleteLikedAttraction)
 
   const handleLikedAttraction = () => {
-    setIsAttractionLiked(mainAttraction.attractionId)
+    // 여기서 로그인 체크 필요
+
     if (isAttractionLiked) {
       deleteLikedAttraction(mainAttraction.attractionId)
     } else {
-      // 여기서 로그인 체크 필요
       addLikedAttraction(mainAttraction)
     }
   }

--- a/src/pages/main/Mypage/LikedAttractions.jsx
+++ b/src/pages/main/Mypage/LikedAttractions.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Box, Typography, Checkbox, FormControlLabel } from '@mui/material'
+import { TbMinusVertical } from 'react-icons/tb'
+import { useStore } from '../../../components/store/store'
+import TourItem from '../../../components/search/TourItem'
+
+export default function LikedAttractions() {
+  const attractions = useStore((store) => store.likedAttractions) // store에서 내가 찜한 관광지 목록
+  const { deleteLikedAttraction } = useStore()
+  const [checkItems, setCheckItems] = useState([])
+
+  const handleChange = (e) => {
+    if (e.target.checked) {
+      setCheckItems((prev) => [...prev, attraction.attractionId])
+    } else {
+      setCheckItems(checkItems.filter((el) => el !== attraction.attractionId))
+    }
+  }
+  const handleSingleCheck = (checked, attractionId) => {
+    if (checked) {
+      setCheckItems((prev) => [...prev, attractionId])
+    } else {
+      setCheckItems(checkItems.filter((id) => id !== attractionId))
+    }
+  }
+
+  const handleAllCheck = (checked) => {
+    if (checked) {
+      setCheckItems([
+        ...attractions.map((attraction) => attraction.attractionId),
+      ])
+    } else {
+      setCheckItems([])
+    }
+  }
+
+  const handelDelete = () => {
+    checkItems.map((attractionId) => deleteLikedAttraction(attractionId))
+  }
+
+  return (
+    <Box
+      className="flex flex-col justify-center w-full"
+      style={{ width: '100%' }}
+    >
+      <Box className="ml-2">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={checkItems.length === attractions.length}
+              onChange={(e) => handleAllCheck(e.target.checked)}
+              sx={{
+                fontSize: 28,
+                marginLeft: '1rem',
+                marginBottom: '0.25rem',
+              }}
+            />
+          }
+          label={
+            <Typography
+              variant="body2"
+              component="span"
+              className="text-gray-900"
+              style={{ fontWeight: 600 }}
+            >
+              전체선택
+            </Typography>
+          }
+        />
+        <TbMinusVertical className="text-gray-400 my-5 -ml-2 inline text-[1.5rem]" />
+        <Typography
+          onClick={() => handelDelete()}
+          className="text-gray-900 my-5"
+          variant="body2"
+          component="span"
+          style={{ fontWeight: 600 }}
+        >
+          선택삭제
+        </Typography>
+      </Box>
+      <Box className="grid w-full max-w-6xl sm:grid-cols-1 sm:gap-x-6">
+        {attractions.length ? (
+          attractions.map((attraction) => (
+            <Box key={attraction.attractionId} className="felx">
+              <Checkbox
+                checked={!!checkItems.includes(attraction.attractionId)}
+                onChange={(e) =>
+                  handleSingleCheck(e.target.checked, attraction.attractionId)
+                }
+                sx={{
+                  fontSize: 28,
+                  position: 'absolute',
+                  display: 'inline',
+                  marginTop: '2rem',
+                  marginLeft: '1rem',
+                }}
+              />
+              <Box className="w-full">
+                <TourItem
+                  key={attraction.attractionId}
+                  attraction={attraction}
+                  likedPage="true"
+                />
+              </Box>
+            </Box>
+          ))
+        ) : (
+          <Typography
+            className="text-gray-900"
+            style={{
+              display: 'inline',
+              fontWeight: 600,
+              fontSize: '1.5rem',
+            }}
+            variant="body1"
+            component="span"
+          >
+            여행지 정보가 없습니다
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/pages/main/Mypage/LikedPlace.jsx
+++ b/src/pages/main/Mypage/LikedPlace.jsx
@@ -1,0 +1,5 @@
+import { Box } from '@mui/system'
+
+export default function LikedPlace() {
+  return <Box />
+}

--- a/src/pages/main/Mypage/LikedPlace.jsx
+++ b/src/pages/main/Mypage/LikedPlace.jsx
@@ -1,5 +1,0 @@
-import { Box } from '@mui/system'
-
-export default function LikedPlace() {
-  return <Box />
-}


### PR DESCRIPTION
### 마이페이지 내의 찜한 목록페이지
- 선택삭제 전체삭제기능
### 모든 투어 아이템 컴포넌트마다 찜하기 버튼(하트) 추가, 작동

### store 변경사항
- 찜한 아이템인지 체크하는 부분을 store에서 가져오는 부분은 map안에 있는 투어 아이템에서 클릭이벤트를 의존성배열로 넣고 useEffect에서 업데이트 했을때 무한 호출되는 에러로 인해 useState로 변경

### 추가 구현할 부분
- 로그인시 회원정보 호출할때 store의 setLikedAttractions에 response data의 찜한관광지목록 가져와서 초기화
(나영님과 상의 필요)
- api에서 즐겨찾기 추가 삭제가 가능해져서 store에 추가예정(추가 삭제시 api호출로 회원정보의 찜한목록 update)

![스크린샷 2023-12-06 120800](https://github.com/Daram1213/TripleS/assets/125113492/55718cca-b2e4-4e7e-ab0c-07723997518f)
![스크린샷 2023-12-06 120820](https://github.com/Daram1213/TripleS/assets/125113492/f4b03a5d-5a1d-4b7b-83f0-08a2a3ec09c0)
![스크린샷 2023-12-06 120837](https://github.com/Daram1213/TripleS/assets/125113492/f3d0b849-ee77-45a1-8f52-f4daf325dd5e)
