### PR TITLE
feat: 즐겨찾기, 추가삭제시 api호출

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/base": "^5.0.0-beta.24",
-        "@mui/icons-material": "^5.14.18",
+        "@mui/icons-material": "^5.14.19",
         "@mui/lab": "^5.0.0-alpha.153",
         "@mui/material": "^5.14.18",
         "@mui/system": "^5.14.18",
@@ -812,18 +812,18 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.14.18",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.18.tgz",
-      "integrity": "sha512-o2z49R1G4SdBaxZjbMmkn+2OdT1bKymLvAYaB6pH59obM1CYv/0vAVm6zO31IqhwtYwXv6A7sLIwCGYTaVkcdg==",
+      "version": "5.14.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
+      "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2"
+        "@babel/runtime": "^7.23.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/base": "^5.0.0-beta.24",
-    "@mui/icons-material": "^5.14.18",
+    "@mui/icons-material": "^5.14.19",
     "@mui/lab": "^5.0.0-alpha.153",
     "@mui/material": "^5.14.18",
     "@mui/system": "^5.14.18",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import SearchHotelList from './pages/search/SearchHotelList'
 import SearchTourList from './pages/search/SearchTourList'
 import TourDetail from './pages/tour/tourDetail'
 import MyPage from './pages/main/Mypage/Mypage'
+import LikedAttractions from './pages/main/Mypage/LikedAttractions'
 
 function App() {
   const theme = createTheme()
@@ -37,7 +38,9 @@ function App() {
                 <Route path="/hotel" element={<HotelPage />} />
                 <Route path="/hotel/search" element={<HotelSearchPage />} />
                 <Route path="/myPage" element={<MyPage />} />
-                {/* 통합검색, 호텔리스트, 여행지리스트 */}
+                {/* 마이페이지에 아울렛으로 넣어야 할것같은데 확인 위해 일단 빼 두었습니다 */}
+                <Route path="/like" element={<LikedAttractions />} />
+
                 <Route path="/searchList/:keyword" element={<SearchPage />} />
                 <Route
                   path="/searchHotelList/:keyword"

--- a/src/components/search/SearchCard.jsx
+++ b/src/components/search/SearchCard.jsx
@@ -7,7 +7,7 @@ import TourItem from './TourItem'
 
 function SearchCard({ hotels, attractions, keyword }) {
   return (
-    <Box className="flex flex-col items-center gap-3">
+    <Box className="flex flex-col items-center gap-3 mt-5">
       <Typography
         className="text-gray-900 w-[84rem]"
         style={{
@@ -119,7 +119,7 @@ function SearchCard({ hotels, attractions, keyword }) {
                 여행지
               </Typography>
 
-              <Box className="grid w-full max-w-6xl  sm:grid-cols-1 sm:gap-x-6 md:grid-cols-2 xl:grid-cols-3">
+              <Box className="grid w-full max-w-6xl sm:grid-cols-1 sm:gap-x-6 md:grid-cols-2 xl:grid-cols-3">
                 {attractions.length ? (
                   attractions.map((attraction) => (
                     <TourItem

--- a/src/components/search/TourItem.jsx
+++ b/src/components/search/TourItem.jsx
@@ -1,76 +1,127 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Box, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
+import { CiHeart } from 'react-icons/ci'
+import { FaHeart } from 'react-icons/fa'
+import Checkbox from '@mui/material/Checkbox'
+import { useStore } from '../store/store'
 
-function TourItem({ attraction, smallCard }) {
+function TourItem({ attraction, smallCard, likedPage }) {
   const city = useMemo(
     () => (attraction?.address ? attraction.address.split(' ')[0] : ''),
     [attraction],
   )
 
+  const [isAttractionLiked, setIsAttractionLiked] = useState(false)
+  const { likedAttractions, deleteLikedAttraction, addLikedAttraction } =
+    useStore()
+
+  const handleLikedAttraction = () => {
+    if (isAttractionLiked) {
+      deleteLikedAttraction(attraction.attractionId)
+    } else {
+      addLikedAttraction(attraction)
+    }
+  }
+
+  useEffect(() => {
+    setIsAttractionLiked(
+      likedAttractions?.some(
+        (attr) => attr.attractionId === attraction.attractionId,
+      ),
+    )
+  }, [attraction, likedAttractions])
+
   return (
-    <Link to={`/tourDetail/${attraction.attractionId}`}>
-      <Box
-        className={`group relative flex overflow-hidden border border-solid border-gray-200 bg-white ${
-          smallCard
-            ? 'h-23 mb-2'
-            : 'h-29 mb-6 hover:border-blue-200 hover:shadow-lg hover:shadow-blue-100'
-        }`}
-      >
+    <Box className={`relative ${likedPage ? 'pl-20' : ''}`}>
+      <Link to={`/tourDetail/${attraction.attractionId}`}>
         <Box
-          className={` overflow-hidden
+          className={`group relative flex overflow-hidden border border-solid border-gray-200 bg-white ${
+            smallCard
+              ? 'h-23 mb-2'
+              : 'h-29 mb-6 hover:border-blue-200 hover:shadow-lg hover:shadow-blue-100'
+          }`}
+        >
+          <Box
+            className={` overflow-hidden
             ${smallCard ? 'h-[6rem] w-[6rem]' : 'h-[8rem] w-[8rem]'}
           `}
-        >
-          <img
-            src={`/src/assets/img/attraction/${attraction.mainImage}`}
-            className={`object-cover 
+          >
+            <img
+              src={`/src/assets/img/attraction/${attraction.mainImage}`}
+              className={`object-cover 
               ${
                 smallCard
                   ? 'h-[6rem] w-[6rem]'
                   : 'h-[8rem] w-[8rem] overflow-hidden duration-1000 group-hover:scale-125'
               }`}
-            alt={`attraction ${attraction.attractionId}`}
-          />
-        </Box>
-        <Box className=" flex flex-col items-start justify-start gap-1 px-2 py-1.5 text-gray-500">
-          <Typography
-            variant="body1"
-            className=" text-gray-900"
-            style={{ fontWeight: 600 }}
-          >
-            {attraction.name}
-          </Typography>
-          <Typography variant="body1" className="-mt-1">
-            {city}
-          </Typography>
-
-          <Box className="-mt-1.5">
+              alt={`attraction ${attraction.attractionId}`}
+            />
+          </Box>
+          <Box className=" flex flex-col items-start justify-start gap-1 px-2 py-1.5 text-gray-500">
             <Typography
               variant="body1"
-              className=" text-blue-500"
-              style={smallCard ? { display: 'inline' } : { display: 'inline' }}
+              className=" text-gray-900"
+              style={{ fontWeight: 600 }}
             >
-              {attraction.avgRating}
+              {attraction.name}
             </Typography>
-            <Typography
-              variant="body2"
-              className=" text-gray-500"
-              style={{ display: 'inline' }}
-            >
-              /5
+            <Typography variant="body1" className="-mt-1">
+              {city}
             </Typography>
-            <Typography
-              variant="body1"
-              className="ml-2"
-              style={{ marginLeft: '0.5rem', display: 'inline' }}
-            >
-              {attraction.reviewCount}건의 리뷰
-            </Typography>
+            <Box className="-mt-1.5">
+              <Typography
+                variant="body1"
+                className=" text-blue-500"
+                style={
+                  smallCard ? { display: 'inline' } : { display: 'inline' }
+                }
+              >
+                {attraction.avgRating}
+              </Typography>
+              <Typography
+                variant="body2"
+                className=" text-gray-500"
+                style={{ display: 'inline' }}
+              >
+                /5
+              </Typography>
+              <Typography
+                variant="body1"
+                className="ml-2"
+                style={{ marginLeft: '0.5rem', display: 'inline' }}
+              >
+                {attraction.reviewCount}건의 리뷰
+              </Typography>
+            </Box>
           </Box>
         </Box>
-      </Box>
-    </Link>
+      </Link>
+      <Button
+        style={{
+          position: 'absolute',
+          top: '0',
+          right: '-0.5rem',
+          borderRadius: '50%',
+        }}
+      >
+        {isAttractionLiked ? (
+          <FaHeart
+            onClick={() => {
+              handleLikedAttraction()
+            }}
+            className="w-7 h-7 mt-1 text-blue-700"
+          />
+        ) : (
+          <CiHeart
+            onClick={() => {
+              handleLikedAttraction()
+            }}
+            className="w-9 h-9"
+          />
+        )}
+      </Button>
+    </Box>
   )
 }
 

--- a/src/components/store/store.js
+++ b/src/components/store/store.js
@@ -1,37 +1,62 @@
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
+import { useQuery } from 'react-query'
+import fetchAddLikes from '../../fetch/fetchAddLikes'
+import fetchDeleteLikes from '../../fetch/fetchDeleteLikes'
 
-const store = (set) => ({
+const store = (set, get) => ({
   likedAttractions: [],
-  addLikedAttraction: (attraction) =>
+  // 로그인시 유저 정보 조회 후 setLikedAttraction(data.favoriteAttractions)
+  setLikedAttraction: (fetchedAttractions) =>
     set(
-      (state) => ({
-        likedAttractions: [...state.likedAttractions, attraction],
+      () => ({
+        likedAttractions: [...fetchedAttractions],
       }),
       false,
-      'addLikedAttraction',
+      'setLikedAttraction',
     ),
-  deleteLikedAttraction: (id) =>
-    set(
-      (state) => ({
-        likedAttractions: state.likedAttractions.filter(
-          (attraction) => attraction.attractionId !== id,
-        ),
-      }),
-      false,
-      'deleteLikedAttraction',
-    ),
-  isAttractionLiked: false,
-  setAttractionLiked: (id) =>
-    set(
-      (state) => ({
-        isAttractionLiked: state.likedAttractions.some(
-          (attraction) => attraction.attractionId === id,
-        ),
-      }),
-      false,
-      'setAttractionLiked',
-    ),
+  addLikedAttraction: async (attraction) => {
+    try {
+      const attractionExists = get().likedAttractions.some(
+        (item) => item.attractionId === attraction.attractionId,
+      )
+      if (attractionExists) {
+        return
+      }
+
+      const response = await fetchAddLikes(attraction.attractionId)
+
+      if (response) {
+        set(
+          (state) => ({
+            likedAttractions: [...state.likedAttractions, attraction],
+          }),
+          false,
+          'addLikedAttraction',
+        )
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  },
+  deleteLikedAttraction: async (attractionId) => {
+    try {
+      const response = await fetchDeleteLikes(attractionId)
+      if (response) {
+        set(
+          (state) => ({
+            likedAttractions: state.likedAttractions.filter(
+              (attraction) => attraction.attractionId !== attractionId,
+            ),
+          }),
+          false,
+          'deleteLikedAttraction',
+        )
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  },
 })
 
 export const useStore = create(persist(devtools(store), { name: 'store' }))

--- a/src/components/tour/TourDetailHeader.jsx
+++ b/src/components/tour/TourDetailHeader.jsx
@@ -8,6 +8,7 @@ import { Typography } from '@mui/material'
 import { Button } from '@mui/base'
 import moment from 'moment/moment'
 import { shallow } from 'zustand/shallow'
+import { useEffect, useState } from 'react'
 import { useStore } from '../store/store'
 
 export default function TourDetailHeader({ mainAttraction, city }) {
@@ -52,24 +53,26 @@ export default function TourDetailHeader({ mainAttraction, city }) {
     return '영업종료'
   }
 
-  const likedAttractions = useStore((store) => store.likedAttractions)
-  const setAttractionLiked = useStore((store) => store.setAttractionLiked)
+  const { likedAttractions, addLikedAttraction, deleteLikedAttraction } =
+    useStore()
 
-  const isAttractionLiked = useStore((store) => store.isAttractionLiked)
-
-  const addLikedAttraction = useStore((store) => store.addLikedAttraction)
-  const deleteLikedAttraction = useStore((store) => store.deleteLikedAttraction)
+  const [isAttractionLiked, setIsAttractionLiked] = useState(false)
 
   const handleLikedAttraction = () => {
-    setAttractionLiked(mainAttraction.attractionId)
     if (isAttractionLiked) {
       deleteLikedAttraction(mainAttraction.attractionId)
     } else {
-      // 여기서 로그인 체크 필요
       addLikedAttraction(mainAttraction)
     }
-    setAttractionLiked(mainAttraction.attractionId)
   }
+
+  useEffect(() => {
+    setIsAttractionLiked(
+      likedAttractions?.some(
+        (attr) => attr.attractionId === mainAttraction.attractionId,
+      ),
+    )
+  }, [likedAttractions, mainAttraction])
 
   return (
     <Box className="flex flex-col gap-2 p-3">

--- a/src/fetch/fetchAddLikes.js
+++ b/src/fetch/fetchAddLikes.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+function getCookie(name) {
+  const cookies = document.cookie.split(';')
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim()
+    if (cookie.startsWith(`${name}=`)) {
+      return cookie.substring(name.length + 1)
+    }
+  }
+  return null
+}
+
+const fetchAddLikes = async (attraction) => {
+  try {
+    const accessToken = getCookie('accessToken')
+    if (!accessToken) {
+      throw new Error('토큰 정보가 없습니다')
+    }
+    const accessTokenObject = JSON.parse(accessToken)
+    const tokenValue = accessTokenObject.token
+
+    const response = await axios.post(
+      'http://15.165.25.34:3000/api/users/favorites',
+      {
+        attraction,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${tokenValue}`,
+        },
+      },
+    )
+    return response.data
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
+export default fetchAddLikes

--- a/src/fetch/fetchDeleteLikes.js
+++ b/src/fetch/fetchDeleteLikes.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+function getCookie(name) {
+  const cookies = document.cookie.split(';')
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim()
+    if (cookie.startsWith(`${name}=`)) {
+      return cookie.substring(name.length + 1)
+    }
+  }
+  return null
+}
+
+const fetchDeleteLikes = async (attraction) => {
+  try {
+    const accessToken = getCookie('accessToken')
+    if (!accessToken) {
+      throw new Error('토큰 정보가 없습니다')
+    }
+    const accessTokenObject = JSON.parse(accessToken)
+    const tokenValue = accessTokenObject.token
+
+    const response = await axios.delete(
+      'http://15.165.25.34:3000/api/users/favorites',
+      {
+        attraction,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${tokenValue}`,
+        },
+      },
+    )
+    return response.data
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
+export default fetchDeleteLikes

--- a/src/pages/main/Mypage/LikedAttractions.jsx
+++ b/src/pages/main/Mypage/LikedAttractions.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Box, Typography, Checkbox, FormControlLabel } from '@mui/material'
+import { TbMinusVertical } from 'react-icons/tb'
+import { useStore } from '../../../components/store/store'
+import TourItem from '../../../components/search/TourItem'
+
+export default function LikedAttractions() {
+  const attractions = useStore((store) => store.likedAttractions) // store에서 내가 찜한 관광지 목록
+  const { deleteLikedAttraction } = useStore()
+  const [checkItems, setCheckItems] = useState([])
+
+  const handleChange = (e) => {
+    if (e.target.checked) {
+      setCheckItems((prev) => [...prev, attraction.attractionId])
+    } else {
+      setCheckItems(checkItems.filter((el) => el !== attraction.attractionId))
+    }
+  }
+  const handleSingleCheck = (checked, attractionId) => {
+    if (checked) {
+      setCheckItems((prev) => [...prev, attractionId])
+    } else {
+      setCheckItems(checkItems.filter((id) => id !== attractionId))
+    }
+  }
+
+  const handleAllCheck = (checked) => {
+    if (checked) {
+      setCheckItems([
+        ...attractions.map((attraction) => attraction.attractionId),
+      ])
+    } else {
+      setCheckItems([])
+    }
+  }
+
+  const handelDelete = () => {
+    checkItems.map((attractionId) => deleteLikedAttraction(attractionId))
+  }
+
+  return (
+    <Box
+      className="flex flex-col justify-center w-full"
+      style={{ width: '100%' }}
+    >
+      <Box className="ml-2">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={checkItems.length === attractions.length}
+              onChange={(e) => handleAllCheck(e.target.checked)}
+              sx={{
+                fontSize: 28,
+                marginLeft: '1rem',
+                marginBottom: '0.25rem',
+              }}
+            />
+          }
+          label={
+            <Typography
+              variant="body2"
+              component="span"
+              className="text-gray-900"
+              style={{ fontWeight: 600 }}
+            >
+              전체선택
+            </Typography>
+          }
+        />
+        <TbMinusVertical className="text-gray-400 my-5 -ml-2 inline text-[1.5rem]" />
+        <Typography
+          onClick={() => handelDelete()}
+          className="text-gray-900 my-5"
+          variant="body2"
+          component="span"
+          style={{ fontWeight: 600 }}
+        >
+          선택삭제
+        </Typography>
+      </Box>
+      <Box className="grid w-full max-w-6xl sm:grid-cols-1 sm:gap-x-6">
+        {attractions.length ? (
+          attractions.map((attraction) => (
+            <Box key={attraction.attractionId} className="felx">
+              <Checkbox
+                checked={!!checkItems.includes(attraction.attractionId)}
+                onChange={(e) =>
+                  handleSingleCheck(e.target.checked, attraction.attractionId)
+                }
+                sx={{
+                  fontSize: 28,
+                  position: 'absolute',
+                  display: 'inline',
+                  marginTop: '2rem',
+                  marginLeft: '1rem',
+                }}
+              />
+              <Box className="w-full">
+                <TourItem
+                  key={attraction.attractionId}
+                  attraction={attraction}
+                  likedPage="true"
+                />
+              </Box>
+            </Box>
+          ))
+        ) : (
+          <Typography
+            className="text-gray-900"
+            style={{
+              display: 'inline',
+              fontWeight: 600,
+              fontSize: '1.5rem',
+            }}
+            variant="body1"
+            component="span"
+          >
+            여행지 정보가 없습니다
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/pages/search/SearchPage.jsx
+++ b/src/pages/search/SearchPage.jsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { Box } from '@mui/material'
 import SearchCard from '../../components/search/SearchCard'
 import fetchSearchTour from '../../fetch/fetchSearchTour'
 import fetchSearchHotel from '../../fetch/fetchSearchHotel'
+import CommonHeader from '../main/CommonHeader'
 
 function SearchPage() {
   const { keyword } = useParams()
@@ -49,7 +51,10 @@ function SearchPage() {
   }, [attractions, attractionData, attractionRes.isLoading])
 
   return (
-    <SearchCard hotels={hotels} attractions={attractions} keyword={keyword} />
+    <Box>
+      <CommonHeader />
+      <SearchCard hotels={hotels} attractions={attractions} keyword={keyword} />
+    </Box>
   )
 }
 

--- a/src/pages/tour/TourDetail.jsx
+++ b/src/pages/tour/TourDetail.jsx
@@ -9,6 +9,7 @@ import TourMap from '../../components/tour/TourMap'
 import TourPhoto from '../../components/tour/TourPhoto'
 import TourDetailCard from '../../components/tour/tourDetailCard'
 import TourDetailHeader from '../../components/tour/TourDetailHeader'
+import CommonHeader from '../main/CommonHeader'
 
 function TourDetail() {
   const { tourId } = useParams()
@@ -61,24 +62,29 @@ function TourDetail() {
   }
 
   return (
-    <Box className="container flex flex-col items-center gap-3">
-      <Box className="w-[70rem]">
-        <TourDetailHeader mainAttraction={mainAttraction} city={city} />
-        <Box className="flex w-full p-3 gap-3">
-          <TourDetailCard
-            attractionName={mainAttraction.name}
-            attractionDescription={mainAttraction.description}
-            recommendTourTime={mainAttraction.recommendTourTime}
+    <Box className="flex flex-col items-center">
+      <Box className="w-full">
+        <CommonHeader />
+      </Box>
+      <Box className="container flex flex-col items-center gap-3">
+        <Box className="w-[70rem]">
+          <TourDetailHeader mainAttraction={mainAttraction} city={city} />
+          <Box className="flex w-full p-3 gap-3">
+            <TourDetailCard
+              attractionName={mainAttraction.name}
+              attractionDescription={mainAttraction.description}
+              recommendTourTime={mainAttraction.recommendTourTime}
+            />
+            <TourPhoto images={mainAttraction.image} />
+          </Box>
+          <TourMap
+            mainAttraction={mainAttraction}
+            attractions={attractions.filter(
+              (attraction) =>
+                attraction.attractionId !== mainAttraction.attractionId,
+            )}
           />
-          <TourPhoto images={mainAttraction.image} />
         </Box>
-        <TourMap
-          mainAttraction={mainAttraction}
-          attractions={attractions.filter(
-            (attraction) =>
-              attraction.attractionId !== mainAttraction.attractionId,
-          )}
-        />
       </Box>
     </Box>
   )


### PR DESCRIPTION
## 이전과 같은부분
이전에 코치님한테 TourDetailHeader안에서 setIsLikedAttraction 의존성에 함수를 넣어야하는지 피드백을 받아
의존성 배열에서 함수가 아닌 likedAttraction으로 바꾸었습니다.

## 새로 추가한 부분
- 헤더 임포트(서치페이지, 투어디테일)
- fetchAddLikes, fetchDeleteLikes 만듦
- store에서 즐겨찾기 추가, 삭제 시 api호출 후 추가, 삭제 되게 변경 